### PR TITLE
Added neutron radiation

### DIFF
--- a/src/main/java/com/builtbroken/atomic/AtomicScience.java
+++ b/src/main/java/com/builtbroken/atomic/AtomicScience.java
@@ -2,6 +2,7 @@ package com.builtbroken.atomic;
 
 import com.builtbroken.atomic.api.accelerator.IAcceleratorMagnet;
 import com.builtbroken.atomic.api.accelerator.IAcceleratorTube;
+import com.builtbroken.atomic.api.neutron.INeutronSource;
 import com.builtbroken.atomic.api.radiation.IRadiationResistant;
 import com.builtbroken.atomic.api.radiation.IRadiationSource;
 import com.builtbroken.atomic.api.thermal.IThermalSource;
@@ -16,11 +17,14 @@ import com.builtbroken.atomic.content.machines.accelerator.magnet.CapabilityMagn
 import com.builtbroken.atomic.content.machines.processing.ProcessorRecipeHandler;
 import com.builtbroken.atomic.lib.MassHandler;
 import com.builtbroken.atomic.lib.placement.PlacementQueue;
+import com.builtbroken.atomic.lib.neutron.NeutronHandler;
 import com.builtbroken.atomic.lib.radiation.RadiationHandler;
 import com.builtbroken.atomic.lib.thermal.ThermalHandler;
 import com.builtbroken.atomic.map.MapHandler;
 import com.builtbroken.atomic.map.exposure.thread.ThreadRadExposure;
 import com.builtbroken.atomic.map.exposure.node.RadSourceMap;
+import com.builtbroken.atomic.map.neutron.node.NeutronSourceMap;
+import com.builtbroken.atomic.map.neutron.thread.ThreadNeutronExposure;
 import com.builtbroken.atomic.map.thermal.thread.ThreadThermalAction;
 import com.builtbroken.atomic.map.thermal.node.ThermalSourceMap;
 import com.builtbroken.atomic.network.netty.PacketSystem;
@@ -144,6 +148,7 @@ public class AtomicScience
         MapHandler.register();
         ThermalHandler.init();
         RadiationHandler.init();
+        NeutronHandler.init();
         MassHandler.init();
 
         proxyLoader = new ProxyLoader("AS");
@@ -205,6 +210,23 @@ public class AtomicScience
                 },
                 () -> new RadSourceMap(0, BlockPos.ORIGIN, 0));
 
+        CapabilityManager.INSTANCE.register(INeutronSource.class, new Capability.IStorage<INeutronSource>()
+        {
+            @Nullable
+            @Override
+            public NBTBase writeNBT(Capability<INeutronSource> capability, INeutronSource instance, EnumFacing side)
+            {
+                return null;
+            }
+
+            @Override
+            public void readNBT(Capability<INeutronSource> capability, INeutronSource instance, EnumFacing side, NBTBase nbt)
+            {
+
+            }
+        },
+        () -> new NeutronSourceMap(0, BlockPos.ORIGIN, 0));
+        
         CapabilityManager.INSTANCE.register(IThermalSource.class, new Capability.IStorage<IThermalSource>()
                 {
                     @Nullable
@@ -306,6 +328,8 @@ public class AtomicScience
         MapHandler.THREAD_RAD_EXPOSURE.start(); //TODO switch to worker thread
         MapHandler.THREAD_THERMAL_ACTION = new ThreadThermalAction();
         MapHandler.THREAD_THERMAL_ACTION.start(); //TODO switch to worker thread
+        MapHandler.THREAD_NEUTRON_EXPOSURE = new ThreadNeutronExposure();
+        MapHandler.THREAD_NEUTRON_EXPOSURE.start(); //TODO switch to worker thread
     }
 
     @Mod.EventHandler
@@ -323,6 +347,7 @@ public class AtomicScience
         //Kill old thread
         MapHandler.THREAD_RAD_EXPOSURE.kill();
         MapHandler.THREAD_THERMAL_ACTION.kill();
+        MapHandler.THREAD_NEUTRON_EXPOSURE.kill();
     }
 
     /**

--- a/src/main/java/com/builtbroken/atomic/api/AtomicScienceAPI.java
+++ b/src/main/java/com/builtbroken/atomic/api/AtomicScienceAPI.java
@@ -3,6 +3,8 @@ package com.builtbroken.atomic.api;
 import com.builtbroken.atomic.api.accelerator.IAcceleratorMagnet;
 import com.builtbroken.atomic.api.accelerator.IAcceleratorTube;
 import com.builtbroken.atomic.api.effect.IIndirectEffectType;
+import com.builtbroken.atomic.api.neutron.INeutronExposureSystem;
+import com.builtbroken.atomic.api.neutron.INeutronSource;
 import com.builtbroken.atomic.api.radiation.IRadiationExposureSystem;
 import com.builtbroken.atomic.api.radiation.IRadiationResistant;
 import com.builtbroken.atomic.api.radiation.IRadiationSource;
@@ -20,6 +22,9 @@ import net.minecraftforge.common.capabilities.CapabilityInject;
  */
 public final class AtomicScienceAPI
 {
+    /** Generic neutron application, used to apply neutron radiation to entity (does not cause damage) */
+    public static IIndirectEffectType NEUTRON;
+    
     /** Generic radiation application, used to apply radiation to entity (does not cause damage) */
     public static IIndirectEffectType RADIATION;
 
@@ -32,6 +37,9 @@ public final class AtomicScienceAPI
     //  result in mixed logic of some stuff changing while others don't.
     /** System used to access radiation exposure information */
     public static IRadiationExposureSystem radiationExposureSystem;
+    
+    /** System used to access neutron exposure information */
+    public static INeutronExposureSystem neutronExposureSystem;
 
     /** System used to access radioactive material data on the map */
     public static IRadioactiveMaterialSystem radioactiveMaterialSystem;
@@ -41,6 +49,9 @@ public final class AtomicScienceAPI
 
     @CapabilityInject(IThermalSource.class)
     public static Capability<IThermalSource> THERMAL_CAPABILITY = null;
+    
+    @CapabilityInject(INeutronSource.class)
+    public static Capability<INeutronSource> NEUTRON_CAPABILITY = null;
 
     @CapabilityInject(IRadiationSource.class)
     public static Capability<IRadiationSource> RADIATION_CAPABILITY = null;

--- a/src/main/java/com/builtbroken/atomic/api/item/IFuelRodItem.java
+++ b/src/main/java/com/builtbroken/atomic/api/item/IFuelRodItem.java
@@ -1,5 +1,6 @@
 package com.builtbroken.atomic.api.item;
 
+import com.builtbroken.atomic.api.neutron.INeutronItem;
 import com.builtbroken.atomic.api.radiation.IRadioactiveItem;
 import com.builtbroken.atomic.api.reactor.IReactor;
 import net.minecraft.item.ItemStack;
@@ -62,4 +63,13 @@ public interface IFuelRodItem extends IRadioactiveItem
      * @return modified stack
      */
     ItemStack onReactorTick(IReactor reactor, ItemStack stack, int tick, int fuelTick);
+    
+    /**
+     * Strength of neutron radiation the rod represents when active
+     *
+     * @param reactor - reactor consuming the fuel, may be null
+     * @param stack   - fuel rod
+     * @return neutron value
+     */
+    int getNeutronStrength(ItemStack stack, IReactor reactor);
 }

--- a/src/main/java/com/builtbroken/atomic/api/neutron/INeutronExposureSystem.java
+++ b/src/main/java/com/builtbroken/atomic/api/neutron/INeutronExposureSystem.java
@@ -1,0 +1,11 @@
+package com.builtbroken.atomic.api.neutron;
+
+/**
+ * Map system that tracks radioactive material on the map
+ *
+ *
+ * Created by Pu-238 on 8/22/2020.
+ */
+public interface INeutronExposureSystem
+{
+}

--- a/src/main/java/com/builtbroken/atomic/api/neutron/INeutronItem.java
+++ b/src/main/java/com/builtbroken/atomic/api/neutron/INeutronItem.java
@@ -1,0 +1,39 @@
+package com.builtbroken.atomic.api.neutron;
+
+import net.minecraft.item.ItemStack;
+
+/**
+ * Applied to an item to track how much neutron radiation it will produced based on its neutron strength value.
+ * <p>
+ * Will be wrapped by {@link INeutronSource} for logic in the actual world.
+ *
+ *
+ * Created by Pu-238 on 8/22/2020.
+ */
+@Deprecated //Being replaced with capability system
+public interface INeutronItem
+{
+    /**
+     * Gets the amount of radioactive material
+     * this item represents.
+     * <p>
+     * Used to calculate amount of radiation to emit in terms
+     * of NEUs.
+     *
+     * @return material value
+     */
+    int getNeutronStrength(ItemStack stack);
+
+    /**
+     * Is the item still a neutron emitter at the time
+     * this was called. Used as an isAlive() and isValid()
+     * check to see if the source needs to be removed.
+     *
+     * @return true if is still emitting neutrons.
+     */
+    default boolean isNeutronEmitter(ItemStack stack)
+    {
+        return true;
+    }
+
+}

--- a/src/main/java/com/builtbroken/atomic/api/neutron/INeutronNode.java
+++ b/src/main/java/com/builtbroken/atomic/api/neutron/INeutronNode.java
@@ -1,0 +1,24 @@
+package com.builtbroken.atomic.api.neutron;
+
+import com.builtbroken.atomic.api.map.IDataMapNode;
+
+/**
+ *
+ * Created by Pu-238 on 9/21/2018.
+ */
+public interface INeutronNode extends IDataMapNode
+{
+    /**
+     * Gets the current value
+     *
+     * @return
+     */
+    int getNeutronValue();
+
+    /**
+     * Updates the current value
+     *
+     * @param value
+     */
+    void setNeutronValue(int value);
+}

--- a/src/main/java/com/builtbroken/atomic/api/neutron/INeutronSource.java
+++ b/src/main/java/com/builtbroken/atomic/api/neutron/INeutronSource.java
@@ -1,0 +1,67 @@
+package com.builtbroken.atomic.api.neutron;
+
+import com.builtbroken.atomic.api.map.IDataMapSource;
+import com.builtbroken.atomic.lib.transform.IPosWorld;
+import net.minecraft.util.math.BlockPos;
+
+import java.util.HashMap;
+
+/**
+ * Applied to objects that emit neutrons into the environment. Will
+ * be tracked by the exposure thread and updated each tick.
+ * <p>
+ * Source has to be registered to the neutron exposure system in order to be tracked.
+ * <p>
+ * If the source stops emitting neutrons it will unregister. As this is considered
+ * to mean the object is gone or no longer present in the map.
+ * <p>
+ * If the source
+ * starts emitting neutrons again, it will need to be registered again to the map to work.
+ *
+ *
+ * Created by Pu-238 on 8/22/2020.
+ */
+public interface INeutronSource extends IPosWorld, IDataMapSource
+{
+    /**
+     * Current map of positions to nodes
+     *
+     * @return
+     */
+    HashMap<BlockPos, INeutronNode> getCurrentNodes();
+
+    /**
+     * Sets current map of positions to nodes
+     * <p>
+     * Should only be called from pathing thread
+     */
+    void setCurrentNodes(HashMap<BlockPos, INeutronNode> map);
+
+    /**
+     * Gets the amount of neutron radiation
+     * this source represents.
+     * <p>
+     * Used to calculate amount of radiation to emit in terms
+     * of NEUs.
+     * <p>
+     * This value should not change each time the method is called. If
+     * the value is randomized it should be cached until next tick.
+     *
+     * @return material value
+     */
+    int getNeutronStrength();
+
+    /**
+     * Is the source emitting neutrons at the time
+     * this was called.
+     * <p>
+     * {@link #isStillValid()} is to be used as a validation
+     * check instead of this method.
+     *
+     * @return true if is still radioactive
+     */
+    default boolean isNeutronEmitter()
+    {
+        return true;
+    }
+}

--- a/src/main/java/com/builtbroken/atomic/api/reactor/IFissionReactor.java
+++ b/src/main/java/com/builtbroken/atomic/api/reactor/IFissionReactor.java
@@ -1,5 +1,6 @@
 package com.builtbroken.atomic.api.reactor;
 
+import com.builtbroken.atomic.api.neutron.INeutronSource;
 import com.builtbroken.atomic.api.radiation.IRadiationSource;
 
 /**
@@ -18,4 +19,14 @@ public interface IFissionReactor extends IReactor
      * @return
      */
     IRadiationSource getRadiationSource();
+    
+    /**
+     * Called to get the object that handles
+     * neutron radiation for the reactor. This should be a
+     * capability on the tile itself.
+     *
+     * @return
+     */
+    INeutronSource getNeutronSource();
+
 }

--- a/src/main/java/com/builtbroken/atomic/client/ClientProxy.java
+++ b/src/main/java/com/builtbroken/atomic/client/ClientProxy.java
@@ -32,6 +32,8 @@ import java.util.HashMap;
 
 public class ClientProxy extends CommonProxy
 {
+    /** Client Cache: Amount of neutrons in the environment were the player is standing */
+    public static float NEUT_EXPOSURE = 0;
     /** Client Cache: Amount of rads in the environment were the player is standing */
     public static float RAD_EXPOSURE = 0;
     /** Client Cache: Amount of rads the player has taken */
@@ -39,6 +41,8 @@ public class ClientProxy extends CommonProxy
     /** Client Cache: Time until radiation is removed from the player again */
     public static int RAD_REMOVE_TIMER = 0;
 
+    /** Client Cache: Amount of neutrons in the environment were the player is standing */
+    public static float PREV_NEUT_EXPOSURE = 0;
     /** Client Cache: Amount of rads in the environment were the player is standing */
     public static float PREV_RAD_EXPOSURE = 0;
     /** Client Cache: Amount of rads the player has taken */

--- a/src/main/java/com/builtbroken/atomic/config/logic/ConfigRadiation.java
+++ b/src/main/java/com/builtbroken/atomic/config/logic/ConfigRadiation.java
@@ -104,11 +104,20 @@ public class ConfigRadiation extends ContentProxy
 
     public static int RADIOACTIVE_REACTOR_VALUE_FUEL_ROD = RADIOACTIVE_MAT_VALUE_FUEL_ROD * 100;
     public static int RADIOACTIVE_REACTOR_VALUE_BREEDER_ROD = RADIOACTIVE_MAT_VALUE_BREEDER_ROD * 100;
+    
+    public static int NEUTRON_VALUE_FUEL_ROD = RADIOACTIVE_REACTOR_VALUE_FUEL_ROD * 2;
+    public static int NEUTRON_VALUE_BREEDER_ROD = 0;
 
     public static float RADIATION_DECAY_PER_BLOCK = 0.05f;
     public static float RADIATION_DECAY_PER_FLUID = 0.15f;
     public static float RADIATION_DECAY_METAL = 0.50f;
     public static float RADIATION_DECAY_STONE = 0.20f;
+    
+    public static float NEUTRON_DECAY_PER_BLOCK = 0.10f;
+    public static float NEUTRON_DECAY_PER_FLUID = 0.45f;
+    public static float NEUTRON_DECAY_METAL = 0.25f;
+    public static float NEUTRON_DECAY_STONE = 0.30f;
+
 
     public ConfigRadiation()
     {

--- a/src/main/java/com/builtbroken/atomic/content/ASIndirectEffects.java
+++ b/src/main/java/com/builtbroken/atomic/content/ASIndirectEffects.java
@@ -32,6 +32,7 @@ public class ASIndirectEffects
     public static final String NBT_RADS_PREV = "prev_rads";
     /** NBT tag used to track prev environment value to see if a packet is needed */
     public static final String NBT_RADS_ENVIROMENT_PREV = "prev_env_rads";
+    public static final String NBT_NEUTRON_ENVIROMENT_PREV = "prev_env_neuts";
 
     /** NBT tag used to store last rad remove time on an entity */
     public static final String NBT_RADS_REMOVE_TIMER = "remove_timer";

--- a/src/main/java/com/builtbroken/atomic/content/ASItems.java
+++ b/src/main/java/com/builtbroken/atomic/content/ASItems.java
@@ -136,12 +136,14 @@ public final class ASItems
                 () -> ConfigContent.REACTOR.FUEL_ROD_RUNTIME,
                 () -> ConfigRadiation.RADIOACTIVE_MAT_VALUE_FUEL_ROD
                 , () -> ConfigRadiation.RADIOACTIVE_REACTOR_VALUE_FUEL_ROD,
-                () -> ConfigContent.REACTOR.HEAT_REACTOR_FUEL_ROD));
+                () -> ConfigContent.REACTOR.HEAT_REACTOR_FUEL_ROD
+                , () -> ConfigRadiation.NEUTRON_VALUE_FUEL_ROD));
         event.getRegistry().register(itemBreederFuelCell = new ItemFuelRod("breeder_fuel_cell", "cell.fuel.breeder",
                 () -> ConfigContent.REACTOR.BREEDER_ROD_RUNTIME,
                 () -> ConfigRadiation.RADIOACTIVE_MAT_VALUE_BREEDER_ROD
                 , () -> ConfigRadiation.RADIOACTIVE_REACTOR_VALUE_BREEDER_ROD,
-                () -> ConfigContent.REACTOR.HEAT_REACTOR_BREEDER_ROD));
+                () -> ConfigContent.REACTOR.HEAT_REACTOR_BREEDER_ROD
+                , () -> ConfigRadiation.NEUTRON_VALUE_BREEDER_ROD));
 
         //Crafting items
         event.getRegistry().register(itemEmptyCell = new Item()

--- a/src/main/java/com/builtbroken/atomic/content/effects/RadiationEntityEventHandler.java
+++ b/src/main/java/com/builtbroken/atomic/content/effects/RadiationEntityEventHandler.java
@@ -258,6 +258,10 @@ public class RadiationEntityEventHandler
             float exposure = MapHandler.RADIATION_MAP.getRemExposure(player);
             float prev_exposure = data.getFloat(ASIndirectEffects.NBT_RADS_ENVIROMENT_PREV);
             float delta_exposure = Math.abs(prev_exposure - exposure);
+            
+            float neutrons = MapHandler.NEUTRON_MAP.getNeutronExposure(player);
+            float prev_neutrons = data.getFloat(ASIndirectEffects.NBT_NEUTRON_ENVIROMENT_PREV);
+            float delta_neutrons = Math.abs(prev_neutrons - neutrons);
 
             //Check rad change
             float rad = data.getFloat(ASIndirectEffects.NBT_RADS);
@@ -265,12 +269,13 @@ public class RadiationEntityEventHandler
             float delta_rad = Math.abs(prev_rad - rad);
 
             //Only sync if change has happened in data
-            if (delta_rad > syncError || delta_exposure > syncError || player.ticksExisted % 20 == 0)
+            if (delta_rad > syncError || delta_exposure > syncError || delta_neutrons > syncError || player.ticksExisted % 20 == 0)
             {
                 sendPacket = true;
                 //Update previous, always do in sync to prevent slow creep of precision errors
                 data.setFloat(ASIndirectEffects.NBT_RADS_PREV, rad);
                 data.setFloat(ASIndirectEffects.NBT_RADS_ENVIROMENT_PREV, exposure);
+                data.setFloat(ASIndirectEffects.NBT_NEUTRON_ENVIROMENT_PREV, neutrons);
             }
         }
 
@@ -287,7 +292,8 @@ public class RadiationEntityEventHandler
         PacketSystem.INSTANCE.sendToPlayer(new PacketPlayerRadiation(
                 data.getFloat(ASIndirectEffects.NBT_RADS),
                 MapHandler.RADIATION_MAP.getRemExposure(player),
-                data.getInteger(ASIndirectEffects.NBT_RADS_REMOVE_TIMER)), player);
+                data.getInteger(ASIndirectEffects.NBT_RADS_REMOVE_TIMER),
+                MapHandler.NEUTRON_MAP.getNeutronExposure(player)), player);
     }
 
     @SubscribeEvent
@@ -300,7 +306,7 @@ public class RadiationEntityEventHandler
             {
                 float remExposure = MapHandler.RADIATION_MAP.getRemExposure(event.getEntity());
                 System.out.println(remExposure);
-                PacketSystem.INSTANCE.sendToPlayer(new PacketPlayerRadiation(0, 0, 0), (EntityPlayerMP) event.getEntity());
+                PacketSystem.INSTANCE.sendToPlayer(new PacketPlayerRadiation(0, 0, 0, 0), (EntityPlayerMP) event.getEntity());
             }
         }
     }

--- a/src/main/java/com/builtbroken/atomic/content/effects/client/RenderRadOverlay.java
+++ b/src/main/java/com/builtbroken/atomic/content/effects/client/RenderRadOverlay.java
@@ -46,14 +46,17 @@ public class RenderRadOverlay
                 final float rad_player = interpolate(ClientProxy.PREV_RAD_PLAYER, ClientProxy.RAD_PLAYER, event.getPartialTicks());
                 final float rad_area = interpolate(ClientProxy.PREV_RAD_EXPOSURE, ClientProxy.RAD_EXPOSURE, event.getPartialTicks());
                 final float rad_dead_min = ConfigRadiation.RADIATION_DEATH_POINT / (60 * 20); //Radiation needed to die in 1 min
+                final float neutron_area = interpolate(ClientProxy.PREV_NEUT_EXPOSURE, ClientProxy.NEUT_EXPOSURE, event.getPartialTicks());
 
                 //Format
                 String remDisplay = formatDisplay("PER:", rad_player, "rem");
                 String radDisplay = formatDisplay("ENV: ", rad_area * 20, "rem/s");
+                String neuDisplay = formatDisplay("NEUT: ", neutron_area * 20, "neu/s");
 
                 //Render
                 renderTextWithShadow(remDisplay, left, top, interpolate(startColor, endColor, rad_player / ConfigRadiation.RADIATION_DEATH_POINT).getRGB());
                 renderTextWithShadow(radDisplay, left, top + 10, interpolate(startColor, endColor, rad_area / rad_dead_min).getRGB());
+                renderTextWithShadow(neuDisplay, left, top + 20, interpolate(startColor, endColor, neutron_area / rad_dead_min).getRGB());
 
                 if (AtomicScience.runningAsDev)
                 {
@@ -63,6 +66,7 @@ public class RenderRadOverlay
                 //Set prev
                 ClientProxy.PREV_RAD_PLAYER = rad_player;
                 ClientProxy.PREV_RAD_EXPOSURE = rad_area;
+                ClientProxy.PREV_NEUT_EXPOSURE = neutron_area;
 
                 //End
                 GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);

--- a/src/main/java/com/builtbroken/atomic/content/items/ItemFuelRod.java
+++ b/src/main/java/com/builtbroken/atomic/content/items/ItemFuelRod.java
@@ -32,13 +32,17 @@ public class ItemFuelRod extends ItemRadioactive implements IFuelRodItem
     public final IntSupplier reactorRadioactivity;
     /** Heat of the fuel rod when the reactor is active */
     public final IntSupplier reactorHeatOutput;
+    /** Neutron emissions of the fuel rod when the reactor is active */
+    public final IntSupplier reactorNeutronStrength;
 
-    public ItemFuelRod(String key, String name, IntSupplier maxFuelRuntime, IntSupplier radioactiveMaterialValue, IntSupplier reactorRadioactivity, IntSupplier reactorHeatOutput)
+
+    public ItemFuelRod(String key, String name, IntSupplier maxFuelRuntime, IntSupplier radioactiveMaterialValue, IntSupplier reactorRadioactivity, IntSupplier reactorHeatOutput, IntSupplier reactorNeutronStrength)
     {
         super(key, name, radioactiveMaterialValue);
         this.maxFuelRuntime = maxFuelRuntime;
         this.reactorRadioactivity = reactorRadioactivity;
         this.reactorHeatOutput = reactorHeatOutput;
+        this.reactorNeutronStrength = reactorNeutronStrength;
     }
 
     @Override
@@ -121,4 +125,9 @@ public class ItemFuelRod extends ItemRadioactive implements IFuelRodItem
             items.add(setFuelTime(new ItemStack(this), 0));
         }
     }
+	@Override
+	public int getNeutronStrength(ItemStack stack, IReactor reactor) {
+		return reactorNeutronStrength.getAsInt();
+	}
+
 }

--- a/src/main/java/com/builtbroken/atomic/lib/NeutronItemHandler.java
+++ b/src/main/java/com/builtbroken/atomic/lib/NeutronItemHandler.java
@@ -1,0 +1,23 @@
+package com.builtbroken.atomic.lib;
+
+import com.builtbroken.atomic.api.neutron.INeutronItem;
+import net.minecraft.item.ItemStack;
+
+/**
+ *
+ * Created by Pu-238 on 8/22/2020.
+ */
+public class NeutronItemHandler
+{
+    public static int getNeutronsForItem(ItemStack stack)
+    {
+        int neutrons = 0;
+        if (stack != null && stack.getItem() instanceof INeutronItem)
+        {
+            return ((INeutronItem) stack.getItem()).getNeutronStrength(stack);
+        }
+        //TODO read NBT for rad material
+        return neutrons;
+    }
+
+}

--- a/src/main/java/com/builtbroken/atomic/lib/neutron/NeutronHandler.java
+++ b/src/main/java/com/builtbroken/atomic/lib/neutron/NeutronHandler.java
@@ -1,0 +1,220 @@
+package com.builtbroken.atomic.lib.neutron;
+
+import com.builtbroken.atomic.api.AtomicScienceAPI;
+import com.builtbroken.atomic.api.radiation.IRadiationResistant;
+import com.builtbroken.atomic.config.logic.ConfigRadiation;
+import com.builtbroken.atomic.content.effects.effects.FloatSupplier;
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.init.Blocks;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import java.util.HashMap;
+
+/**
+ *
+ * Created by Pu-238 on 8/22/2020.
+ */
+public class NeutronHandler
+{
+    public static final HashMap<IBlockState, NeutronResistanceSupplier> blockStateToNeutronPercentage = new HashMap();
+    public static final HashMap<Block, NeutronResistanceSupplier> blockToNeutronPercentage = new HashMap();
+    public static final HashMap<Material, FloatSupplier> materialToNeutronPercentage = new HashMap();
+
+    public static void init()
+    {
+        //These values are not based on realism in order to make the game enjoyable
+        setValue(Material.ROCK, () -> ConfigRadiation.NEUTRON_DECAY_STONE);
+        setValue(Material.PISTON, () -> ConfigRadiation.NEUTRON_DECAY_STONE);
+
+        setValue(Material.GROUND, () -> ConfigRadiation.NEUTRON_DECAY_STONE / 1);
+        setValue(Material.GRASS, () -> ConfigRadiation.NEUTRON_DECAY_STONE / 1);
+        setValue(Material.SAND, () -> ConfigRadiation.NEUTRON_DECAY_STONE / 1);
+        setValue(Material.CLAY, () -> ConfigRadiation.NEUTRON_DECAY_STONE / 1);
+
+        setValue(Material.ICE, () -> ConfigRadiation.NEUTRON_DECAY_PER_FLUID / 1);
+        setValue(Material.PACKED_ICE, () -> ConfigRadiation.NEUTRON_DECAY_PER_FLUID / 1);
+        setValue(Material.CRAFTED_SNOW, () -> ConfigRadiation.NEUTRON_DECAY_PER_FLUID / 1);
+
+        setValue(Material.IRON, () -> ConfigRadiation.NEUTRON_DECAY_METAL);
+
+        setValue(Blocks.BRICK_BLOCK, (world, pos, state) -> ConfigRadiation.NEUTRON_DECAY_STONE * 1.2f);
+        setValue(Blocks.NETHER_BRICK, (world, pos, state) -> ConfigRadiation.NEUTRON_DECAY_STONE * 1f);
+        setValue(Blocks.STONEBRICK, (world, pos, state) -> ConfigRadiation.NEUTRON_DECAY_STONE * 1f);
+        setValue(Blocks.QUARTZ_BLOCK, (world, pos, state) -> ConfigRadiation.NEUTRON_DECAY_STONE * 1f);
+        setValue(Blocks.DIAMOND_BLOCK, (world, pos, state) -> ConfigRadiation.NEUTRON_DECAY_PER_FLUID * 2f);
+        setValue(Blocks.GOLD_BLOCK, (world, pos, state) -> ConfigRadiation.NEUTRON_DECAY_METAL * 1.3f);
+        setValue(Blocks.OBSIDIAN, (world, pos, state) -> ConfigRadiation.NEUTRON_DECAY_STONE * 1.5f);
+        setValue(Blocks.COBBLESTONE, (world, pos, state) -> ConfigRadiation.NEUTRON_DECAY_STONE * 0.7f);
+        setValue(Blocks.MOSSY_COBBLESTONE, (world, pos, state) -> ConfigRadiation.NEUTRON_DECAY_STONE * 0.8f);
+        setValue(Blocks.IRON_DOOR, (world, pos, state) -> ConfigRadiation.NEUTRON_DECAY_METAL / 3);
+        setValue(Blocks.IRON_BARS, (world, pos, state) -> ConfigRadiation.NEUTRON_DECAY_METAL / 4);
+        setValue(Blocks.CONCRETE, (world, pos, state) -> ConfigRadiation.NEUTRON_DECAY_PER_FLUID * 1.7f);
+
+        //TODO add JSON data to allow users to customize values
+
+        //Sources to base values on, do not use real values as 1m dirt can block radiation easily
+        //https://en.wikipedia.org/wiki/Radiation_material_science
+        //https://en.wikipedia.org/wiki/Radiation_protection
+        //https://en.wikipedia.org/wiki/Half-value_layer
+    }
+
+    public static void setValue(Block block, NeutronResistanceSupplier supplier)
+    {
+        blockToNeutronPercentage.put(block, supplier);
+    }
+
+    public static void setValue(IBlockState blockState, NeutronResistanceSupplier supplier)
+    {
+        blockStateToNeutronPercentage.put(blockState, supplier);
+    }
+
+    public static void setValue(Material material, FloatSupplier supplier)
+    {
+        materialToNeutronPercentage.put(material, supplier);
+    }
+
+    /**
+     * Called to get the generalized neutron radiation resistance of a block at the position
+     *
+     * @param world - location
+     * @param xi-   location
+     * @param yi-   location
+     * @param zi-   location
+     * @return value between 0.0 and 1.0
+     */
+    public static float getReduceNeutronsForBlock(World world, int xi, int yi, int zi) //TODO make a directional version
+    {
+        final BlockPos pos = new BlockPos(xi, yi, zi);
+        final IBlockState blockState = world.getBlockState(pos);
+        final Block block = blockState.getBlock();
+
+        TileEntity tileEntity = world.getTileEntity(pos);
+        if (tileEntity != null && tileEntity.hasCapability(AtomicScienceAPI.RADIATION_RESISTANT_CAPABILITY, null))
+        {
+            IRadiationResistant radiationResistant = tileEntity.getCapability(AtomicScienceAPI.RADIATION_RESISTANT_CAPABILITY, null);
+            if (radiationResistant != null)
+            {
+                return radiationResistant.getRadiationResistance();
+            }
+        }
+        else if (blockStateToNeutronPercentage.containsKey(blockState))
+        {
+            return blockStateToNeutronPercentage.get(blockState).getAsFloat(world, pos, blockState);
+        }
+        else if (blockToNeutronPercentage.containsKey(block))
+        {
+            return blockToNeutronPercentage.get(block).getAsFloat(world, pos, blockState);
+        }
+        else if (!block.isAir(blockState, world, pos))
+        {
+            if (blockState.getMaterial().isSolid())
+            {
+                if (blockState.isOpaqueCube())
+                {
+                    final Material material = blockState.getMaterial();
+                    if (materialToNeutronPercentage.containsKey(material))
+                    {
+                        return materialToNeutronPercentage.get(material).getAsFloat();
+                    }
+                    return ConfigRadiation.RADIATION_DECAY_PER_BLOCK;
+                }
+                return ConfigRadiation.RADIATION_DECAY_PER_BLOCK / 2;
+            }
+            else if (blockState.getMaterial().isLiquid())
+            {
+                return ConfigRadiation.RADIATION_DECAY_PER_FLUID;
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * Called to reduce the neutron radiation value
+     *
+     * @param world - location
+     * @param xi    - location
+     * @param yi    - location
+     * @param zi    - location
+     * @param power - radiation value
+     * @return reduced value
+     */
+    public static double reduceNeutronForBlock(World world, int xi, int yi, int zi, double power)
+    {
+        //Get reduction
+        float reduction = getReduceNeutronsForBlock(world, xi, yi, zi);
+
+        //TODO add system to allow per block flat limit, then apply greater (limit or percentage)
+        //TODO add an upper limit, how much radiation a block can stop, pick small (limit or percentage)
+        //Flat line
+        if (power < reduction * 1000)
+        {
+            return 0;
+        }
+
+        //Reduce if not flat
+        power -= power * reduction;
+
+
+        //Calculate radiation
+        return power;
+    }
+
+    /**
+     * Converts material value to rad
+     *
+     * @param material_amount - amount of material
+     * @return rad value
+     */
+    public static int getNeutronsFromMaterial(int material_amount)
+    {
+        return (int) Math.ceil(material_amount * ConfigRadiation.MAP_VALUE_TO_MILI_RAD);
+    }
+
+    /**
+     * Gets neutron radiation value for the given distance
+     *
+     * @param power      - ordinal power at 1 meter
+     * @param distanceSQ - distance to get current
+     * @return distance reduced value, if less than 1 will return full
+     */
+    public static double getNeutronsForDistance(double power, double distanceSQ)
+    {
+        //its assumed power is measured at 1 meter from source
+        return getNeutronsForDistance(power, 1, distanceSQ);
+    }
+
+    /**
+     * Gets neutron radiation value for the given distance
+     *
+     * @param power            - ordinal power at 1 meter
+     * @param distanceSourceSQ - distance from source were the power was measured
+     * @param distanceSQ       - distance to get current
+     * @return distance reduced value, if less than 1 will return full
+     */
+    public static double getNeutronsForDistance(double power, double distanceSourceSQ, double distanceSQ)
+    {
+        //http://www.nde-ed.org/GeneralResources/Formula/RTFormula/InverseSquare/InverseSquareLaw.htm
+        if (distanceSQ < distanceSourceSQ)
+        {
+            return power;
+        }
+
+        //I_2 = I * D^2 / D_2^2
+        return (power * distanceSourceSQ) / distanceSQ;
+    }
+
+    /**
+     * At what point does neutron radiation power drop below 1
+     *
+     * @param power - starting value
+     * @return distance
+     */
+    public static double getDecayRange(int power)
+    {
+        return Math.sqrt(power + 1 / 0.5);
+    }
+}

--- a/src/main/java/com/builtbroken/atomic/lib/neutron/NeutronResistanceSupplier.java
+++ b/src/main/java/com/builtbroken/atomic/lib/neutron/NeutronResistanceSupplier.java
@@ -1,0 +1,16 @@
+package com.builtbroken.atomic.lib.neutron;
+
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+@FunctionalInterface
+public interface NeutronResistanceSupplier
+{
+    /**
+     * Gets a result.
+     *
+     * @return a result
+     */
+    float getAsFloat(World world, BlockPos pos, IBlockState state);
+}

--- a/src/main/java/com/builtbroken/atomic/map/MapHandler.java
+++ b/src/main/java/com/builtbroken/atomic/map/MapHandler.java
@@ -5,6 +5,8 @@ import com.builtbroken.atomic.api.AtomicScienceAPI;
 import com.builtbroken.atomic.config.logic.ConfigRadiation;
 import com.builtbroken.atomic.map.exposure.RadiationMap;
 import com.builtbroken.atomic.map.exposure.thread.ThreadRadExposure;
+import com.builtbroken.atomic.map.neutron.NeutronMap;
+import com.builtbroken.atomic.map.neutron.thread.ThreadNeutronExposure;
 import com.builtbroken.atomic.map.thermal.ThermalMap;
 import com.builtbroken.atomic.map.thermal.thread.ThreadThermalAction;
 import net.minecraftforge.common.MinecraftForge;
@@ -21,11 +23,16 @@ import net.minecraftforge.fml.common.gameevent.TickEvent;
  */
 public final class MapHandler
 {
-    public static final String RAD_EXPOSURE_MAP_ID = AtomicScience.PREFIX + "radiation_exposure";
+	public static final String NEUTRON_EXPOSURE_MAP_ID = AtomicScience.PREFIX + "neutron_exposure";
+	public static final String RAD_EXPOSURE_MAP_ID = AtomicScience.PREFIX + "radiation_exposure";
     public static final String RAD_MATERIAL_MAP_ID = AtomicScience.PREFIX + "radiation_material";
 
+    public static final String NBT_NEUTRON_CHUNK = AtomicScience.PREFIX + "neutron_data";
+    
     public static final String NBT_RAD_CHUNK = AtomicScience.PREFIX + "radiation_data";
 
+    /** Handles neutron exposure data storage */
+    public static final NeutronMap NEUTRON_MAP = new NeutronMap(); //TODO expose to API
     /** Handles radiation exposure data storage */
     public static final RadiationMap RADIATION_MAP = new RadiationMap(); //TODO expose to API
     /** Handles radioactive material data storage */
@@ -37,18 +44,22 @@ public final class MapHandler
     public static ThreadRadExposure THREAD_RAD_EXPOSURE;
     /** Thread used to move heat around the map */
     public static ThreadThermalAction THREAD_THERMAL_ACTION;
-
+    /** Thread used to calculate neutron values per location */
+    public static ThreadNeutronExposure THREAD_NEUTRON_EXPOSURE;
+    
     public static final MapHandler INSTANCE = new MapHandler();
 
     public static void register()
     {
-        AtomicScienceAPI.radiationExposureSystem = RADIATION_MAP;
+        AtomicScienceAPI.neutronExposureSystem = NEUTRON_MAP;
+    	AtomicScienceAPI.radiationExposureSystem = RADIATION_MAP;
         AtomicScienceAPI.thermalSystem = THERMAL_MAP;
 
         MinecraftForge.EVENT_BUS.register(INSTANCE);
 
         if (ConfigRadiation.ENABLE_MAP)
         {
+            MinecraftForge.EVENT_BUS.register(NEUTRON_MAP);
             MinecraftForge.EVENT_BUS.register(RADIATION_MAP);
         }
 
@@ -64,6 +75,7 @@ public final class MapHandler
     {
         if (!event.getWorld().isRemote)
         {
+        	NEUTRON_MAP.onWorldUnload(event.getWorld());
             RADIATION_MAP.onWorldUnload(event.getWorld());
             THERMAL_MAP.onWorldUnload(event.getWorld());
             GLOBAL_DATA_MAP.onWorldUnload(event.getWorld());

--- a/src/main/java/com/builtbroken/atomic/map/neutron/NeutronMap.java
+++ b/src/main/java/com/builtbroken/atomic/map/neutron/NeutronMap.java
@@ -1,0 +1,172 @@
+package com.builtbroken.atomic.map.neutron;
+
+import com.builtbroken.atomic.api.map.DataMapType;
+import com.builtbroken.atomic.api.neutron.INeutronExposureSystem;
+import com.builtbroken.atomic.map.MapHandler;
+import com.builtbroken.atomic.map.data.storage.DataMap;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+/**
+ * Handles radiation exposure map. Is not saved and only cached to improve runtime.
+ *
+ *
+ * Created by Pu-238 on 8/22/2020.
+ */
+public class NeutronMap implements INeutronExposureSystem
+{
+    ///----------------------------------------------------------------
+    ///-------- Level Data Accessors
+    ///----------------------------------------------------------------
+
+    /**
+     * Gets the '(REM) roentgen equivalent man' at the given location
+     *
+     * @param world - location
+     * @param pos   - location
+     * @return rem level in mili-rads (1/1000ths of a rem)
+     */
+    public int getNeutronLevel(World world, BlockPos pos)
+    {
+        DataMap map = MapHandler.GLOBAL_DATA_MAP.getMap(world, false);
+        if (map != null)
+        {
+            return map.getValue(pos, DataMapType.NEUTRON);
+        }
+        return 0;
+    }
+
+    /**
+     * Gets the NEU neutron radiation level at the given location
+     *
+     * @param world - location
+     * @param x     - location
+     * @param y     - location
+     * @param z     - location
+     * @return neu level in mili-neus (1/1000ths of a neu)
+     */
+    public int getNeutronLevel(World world, int x, int y, int z)
+    {
+        DataMap map = MapHandler.GLOBAL_DATA_MAP.getMap(world, false);
+        if (map != null)
+        {
+            return map.getValue(x, y, z, DataMapType.NEUTRON);
+        }
+        return 0;
+    }
+
+    /**
+     * Gets the neutron exposure for the entity
+     *
+     * @param entity - entity, will use the entity size to get an average value
+     * @return NEU value
+     */
+    public float getNeutronExposure(Entity entity)
+    {
+        float value = 0;
+
+        //Top point
+        value += getNeutronLevel(entity.world, (int) Math.floor(entity.posX), (int) Math.floor(entity.posY + entity.height), (int) Math.floor(entity.posZ));
+
+        //Mid point
+        value += getNeutronLevel(entity.world, (int) Math.floor(entity.posX), (int) Math.floor(entity.posY + (entity.height / 2)), (int) Math.floor(entity.posZ));
+
+        //Bottom point
+        value += getNeutronLevel(entity.world, (int) Math.floor(entity.posX), (int) Math.floor(entity.posY), (int) Math.floor(entity.posZ));
+
+        //Average TODO build alg to use body size (collision box)
+        value /= 3f;
+
+        //Convert from mili neu to neu
+        value /= 1000f;
+
+        return value;
+    }
+
+    ///----------------------------------------------------------------
+    ///--------Edit events
+    ///----------------------------------------------------------------
+
+    public void onWorldUnload(World world)
+    {
+
+    }
+
+    /*
+    @SubscribeEvent()
+    public void onChunkAdded(MapSystemEvent.AddChunk event)
+    {
+        if (event.world() != null && !event.world().isRemote && event.map.mapSystem == MapHandler.MATERIAL_MAP)
+        {
+            MapHandler.THREAD_RAD_EXPOSURE.queueChunkForAddition(event.chunk);
+        }
+    }
+
+    @SubscribeEvent()
+    public void onChunkRemove(MapSystemEvent.RemoveChunk event)
+    {
+        if (event.world() != null && !event.world().isRemote && event.map.mapSystem == MapHandler.MATERIAL_MAP)
+        {
+            MapHandler.THREAD_RAD_EXPOSURE.queueChunkForRemoval(event.chunk);
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public void onRadiationChange(MapSystemEvent.UpdateValue event)
+    {
+        if (event.world() != null && !event.world().isRemote && event.map.mapSystem == MapHandler.MATERIAL_MAP)
+        {
+            MapHandler.THREAD_RAD_EXPOSURE.queuePosition(DataChange.get(event.dim(), event.x, event.y, event.z, event.prev_value, event.node));
+        }
+    }
+    */
+
+    /*
+    @SubscribeEvent()
+    public void serverTick(TickEvent.ServerTickEvent event)
+    {
+        if (event.phase == TickEvent.Phase.END)
+        {
+            //Cleanup
+            clearDeadSources();
+
+            //Loop sources looking for changes
+            for (RadSourceWrapper wrapper : radiationSourceMap.values())
+            {
+                if (wrapper.hasSourceChanged())
+                {
+                    updateSourceData(wrapper.source, wrapper.source.getRadioactiveMaterial());
+                }
+            }
+        }
+    }
+
+    @SubscribeEvent()
+    public void itemPickUpEvent(PlayerEvent.ItemPickupEvent event)
+    {
+        if (!event.player.world.isRemote)
+        {
+            EntityItem entityItem = event.pickedUp;
+            if (entityItem != null)
+            {
+                ItemStack stack = entityItem.getItem();
+                if (stack != null && stack.getItem() instanceof IRadioactiveItem)
+                {
+                    removeSource(entityItem);
+                }
+            }
+        }
+    }
+
+    @SubscribeEvent()
+    public void entityJoinWorld(EntityJoinWorldEvent event)
+    {
+        if (!event.getWorld().isRemote && event.getEntity().isEntityAlive())
+        {
+            //Add source handles checking if its an actual source
+            addSource(event.getEntity());
+        }
+    }
+    */
+}

--- a/src/main/java/com/builtbroken/atomic/map/neutron/node/NeutronNode.java
+++ b/src/main/java/com/builtbroken/atomic/map/neutron/node/NeutronNode.java
@@ -1,0 +1,80 @@
+package com.builtbroken.atomic.map.neutron.node;
+
+import com.builtbroken.atomic.api.map.DataMapType;
+import com.builtbroken.atomic.api.map.IDataMapSource;
+import com.builtbroken.atomic.api.neutron.INeutronNode;
+import com.builtbroken.atomic.api.neutron.INeutronSource;
+import com.builtbroken.atomic.map.data.DataPool;
+import com.builtbroken.atomic.map.data.IDataPoolObject;
+
+import javax.annotation.Nullable;
+import java.lang.ref.WeakReference;
+
+/**
+ * Created by Pu-238 on 8/22/2020.
+ */
+public class NeutronNode implements INeutronNode, IDataPoolObject
+{
+    private static final DataPool<NeutronNode> NEUTRON_NODE_POOL = new DataPool(400000); //TODO add config
+
+    private WeakReference<INeutronSource> source;
+
+    private int value;
+
+    private NeutronNode(INeutronSource source, int value)
+    {
+        this.source = new WeakReference(source);
+        this.value = value;
+    }
+
+    @Override
+    public int getNeutronValue()
+    {
+        return value;
+    }
+
+    @Override
+    public void setNeutronValue(int value)
+    {
+        this.value = value;
+    }
+
+    @Override
+    public DataMapType getType()
+    {
+        return DataMapType.NEUTRON;
+    }
+
+    @Nullable
+    @Override
+    public IDataMapSource getSource()
+    {
+        if (source == null || source.get() == null)
+        {
+            return null;
+        }
+        return source.get();
+    }
+
+    public static NeutronNode get(INeutronSource source, int value)
+    {
+        if (NEUTRON_NODE_POOL.has())
+        {
+            NeutronNode dataChange = NEUTRON_NODE_POOL.get();
+            if (dataChange != null)
+            {
+                dataChange.source = new WeakReference(source);
+                dataChange.value = value;
+                return dataChange;
+            }
+        }
+        return new NeutronNode(source, value);
+    }
+
+    @Override
+    public void dispose()
+    {
+        source = null;
+        NEUTRON_NODE_POOL.dispose(this);
+    }
+}

--- a/src/main/java/com/builtbroken/atomic/map/neutron/node/NeutronSource.java
+++ b/src/main/java/com/builtbroken/atomic/map/neutron/node/NeutronSource.java
@@ -1,0 +1,65 @@
+package com.builtbroken.atomic.map.neutron.node;
+
+import com.builtbroken.atomic.api.map.DataMapType;
+import com.builtbroken.atomic.api.neutron.INeutronNode;
+import com.builtbroken.atomic.api.neutron.INeutronSource;
+import com.builtbroken.atomic.map.data.node.MapNodeSource;
+import net.minecraft.nbt.NBTTagCompound;
+
+/**
+ *
+ * Created by Pu-238 on 8/22/2020.
+ */
+public abstract class NeutronSource<E> extends MapNodeSource<E, INeutronNode> implements INeutronSource
+{
+    public static final String NBT_NEUTRON = "neutron";
+
+    @Override
+    public boolean isNeutronEmitter()
+    {
+        return getNeutronStrength() > 0;
+    }
+
+    @Override
+    public boolean isStillValid()
+    {
+        return super.isStillValid() && isNeutronEmitter();
+    }
+
+    @Override
+    public DataMapType getType()
+    {
+        return DataMapType.NEUTRON;
+    }
+
+    @Override
+    public NBTTagCompound getSaveState()
+    {
+        NBTTagCompound tagCompound = new NBTTagCompound();
+        tagCompound.setInteger(NBT_NEUTRON, getNeutronStrength());
+        return tagCompound;
+    }
+
+    @Override
+    public boolean shouldQueueForUpdate(NBTTagCompound saveState)
+    {
+        final int material = getNeutronStrength();
+        if (material > 0 && !hasNodes())
+        {
+            return true;
+        }
+        return saveState == null || saveState.getInteger(NBT_NEUTRON) != material;
+    }
+
+    @Override
+    protected String addDebugInfo()
+    {
+        return "NEUT: " + isNeutronEmitter() + "-" + getNeutronStrength() + ", ";
+    }
+
+    @Override
+    protected String getDebugName()
+    {
+        return "NeutronSource";
+    }
+}

--- a/src/main/java/com/builtbroken/atomic/map/neutron/node/NeutronSourceEntity.java
+++ b/src/main/java/com/builtbroken/atomic/map/neutron/node/NeutronSourceEntity.java
@@ -1,0 +1,67 @@
+package com.builtbroken.atomic.map.neutron.node;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.world.World;
+
+import java.lang.ref.WeakReference;
+
+/**
+ *
+ * Created by Pu-238 on 8/22/2020.
+ */
+public abstract class NeutronSourceEntity<E extends Entity> extends NeutronSource<E>
+{
+    private final WeakReference<E> hostReference;
+
+    public NeutronSourceEntity(E host)
+    {
+        hostReference = new WeakReference(host);
+    }
+    @Override
+    public boolean isStillValid()
+    {
+        return super.isStillValid() && !getHost().isDead;
+    }
+
+    @Override
+    public boolean doesSourceExist()
+    {
+        return super.doesSourceExist() && !getHost().isDead;
+    }
+
+    @Override
+    public World world()
+    {
+        return getHost().world;
+    }
+
+    @Override
+    public double z()
+    {
+        return getHost().posZ;
+    }
+
+    @Override
+    public double x()
+    {
+        return getHost().posX;
+    }
+
+    @Override
+    public double y()
+    {
+        return getHost().posY;
+    }
+
+    @Override
+    protected String getDebugName()
+    {
+        return "NeutronSourceEntity";
+    }
+
+    @Override
+    public E getHost()
+    {
+        return hostReference.get();
+    }
+}

--- a/src/main/java/com/builtbroken/atomic/map/neutron/node/NeutronSourceEntityItem.java
+++ b/src/main/java/com/builtbroken/atomic/map/neutron/node/NeutronSourceEntityItem.java
@@ -1,0 +1,38 @@
+package com.builtbroken.atomic.map.neutron.node;
+
+import com.builtbroken.atomic.api.neutron.INeutronItem;
+import com.builtbroken.atomic.config.logic.ConfigRadiation;
+import com.builtbroken.atomic.lib.NeutronItemHandler;
+import net.minecraft.entity.item.EntityItem;
+
+/**
+ * Wrappers an entity item as a source
+ *
+ *
+ * Created by Pu-238 on 8/22/2020.
+ */
+public class NeutronSourceEntityItem extends NeutronSourceEntity<EntityItem>
+{
+    public NeutronSourceEntityItem(EntityItem entity)
+    {
+        super(entity);
+    }
+
+    @Override
+    public int getNeutronStrength()
+    {
+        return NeutronItemHandler.getNeutronsForItem(getHost().getItem());
+    }
+
+    public static NeutronSourceEntityItem build(EntityItem entityItem)
+    {
+        if (ConfigRadiation.ENABLE_ENTITY_ITEMS)
+        {
+            if (entityItem.getItem() != null && entityItem.getItem().getItem() instanceof INeutronItem) //TODO change over to capability
+            {
+                return new NeutronSourceEntityItem(entityItem);
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/builtbroken/atomic/map/neutron/node/NeutronSourceMap.java
+++ b/src/main/java/com/builtbroken/atomic/map/neutron/node/NeutronSourceMap.java
@@ -1,0 +1,86 @@
+package com.builtbroken.atomic.map.neutron.node;
+
+import com.builtbroken.atomic.map.MapHandler;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.common.DimensionManager;
+
+/**
+ * Neutron source taken from the map itself
+ *
+ *
+ * Created by Pu-238 on 8/22/2020.
+ */
+public class NeutronSourceMap extends NeutronSource<BlockPos>
+{
+    private int value;
+    private int dim;
+    private BlockPos pos;
+
+    public NeutronSourceMap(int dim, BlockPos host, int value) //TODO apply flywheel pattern
+    {
+        this.pos = host;
+        this.dim = dim;
+        this.value = value;
+    }
+
+    @Override
+    public int getNeutronStrength()
+    {
+        return value;
+    }
+
+    @Override
+    public double z()
+    {
+        return getHost().getZ() + 0.5;
+    }
+
+    @Override
+    public double x()
+    {
+        return getHost().getX() + 0.5;
+    }
+
+    @Override
+    public double y()
+    {
+        return getHost().getY() + 0.5;
+    }
+
+    @Override
+    public int zi()
+    {
+        return getHost().getZ();
+    }
+
+    @Override
+    public int xi()
+    {
+        return getHost().getX();
+    }
+
+    @Override
+    public int yi()
+    {
+        return getHost().getY();
+    }
+
+    @Override
+    public boolean isStillValid()
+    {
+        return world() != null && world().isBlockLoaded(getHost()) && value == getType().getValue(MapHandler.GLOBAL_DATA_MAP.getData(world(), getHost()));
+    }
+
+    @Override
+    public World world()
+    {
+        return DimensionManager.getWorld(dim);
+    }
+
+    @Override
+    public BlockPos getHost()
+    {
+        return pos;
+    }
+}

--- a/src/main/java/com/builtbroken/atomic/map/neutron/node/NeutronSourcePlayer.java
+++ b/src/main/java/com/builtbroken/atomic/map/neutron/node/NeutronSourcePlayer.java
@@ -1,0 +1,40 @@
+package com.builtbroken.atomic.map.neutron.node;
+
+import com.builtbroken.atomic.lib.NeutronItemHandler;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+
+/**
+ * Wrappers an entity item as a source
+ *
+ *
+ * Created by Pu-238 on 8/22/2020.
+ */
+public class NeutronSourcePlayer extends NeutronSourceEntity<EntityPlayer>
+{
+    public NeutronSourcePlayer(EntityPlayer player)
+    {
+        super(player);
+    }
+
+    @Override
+    public int getNeutronStrength()
+    {
+        if (getHost().isEntityAlive())
+        {
+            int neutrons = 0;
+
+            for (int slot = 0; slot < getHost().inventory.getSizeInventory(); slot++)
+            {
+                ItemStack slotStack = getHost().inventory.getStackInSlot(slot);
+                if (slotStack != null)
+                {
+                    neutrons += NeutronItemHandler.getNeutronsForItem(slotStack);
+                }
+            }
+
+            return neutrons;
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/builtbroken/atomic/map/neutron/node/NeutronSourceTile.java
+++ b/src/main/java/com/builtbroken/atomic/map/neutron/node/NeutronSourceTile.java
@@ -1,0 +1,121 @@
+package com.builtbroken.atomic.map.neutron.node;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+
+import java.lang.ref.WeakReference;
+import java.util.function.BooleanSupplier;
+import java.util.function.IntSupplier;
+
+/**
+ *
+ * Created by Pu-238 on 8/22/2020.
+ */
+public class NeutronSourceTile<E extends TileEntity> extends NeutronSource<E>
+{
+    private final IntSupplier neutronFunction;
+    private final BooleanSupplier activeFunction;
+
+    private final WeakReference<E> hostReference;
+
+    public NeutronSourceTile(E host, IntSupplier neutronFunction, BooleanSupplier activeFunction)
+    {
+        hostReference = new WeakReference(host);
+        this.neutronFunction = neutronFunction;
+        this.activeFunction = activeFunction;
+    }
+
+    @Override
+    public boolean isNeutronEmitter()
+    {
+        return super.isNeutronEmitter() && activeFunction.getAsBoolean();
+    }
+
+    @Override
+    public int getNeutronStrength()
+    {
+        return neutronFunction.getAsInt();
+    }
+
+    @Override
+    public boolean doesSourceExist()
+    {
+        return world() != null
+                && getHost() != null
+                && !getHost().isInvalid()
+                //Fix for chunk ghosting
+                && world().getTileEntity(getPos()) == getHost();
+    }
+
+    @Override
+    public World world()
+    {
+        return getHost().getWorld();
+    }
+
+    @Override
+    public double z()
+    {
+        return getHost().getPos().getZ() + 0.5;
+    }
+
+    @Override
+    public double x()
+    {
+        return getHost().getPos().getX() + 0.5;
+    }
+
+    @Override
+    public double y()
+    {
+        return getHost().getPos().getY() + 0.5;
+    }
+
+    @Override
+    public int zi()
+    {
+        return getHost().getPos().getZ();
+    }
+
+    @Override
+    public int xi()
+    {
+        return getHost().getPos().getX();
+    }
+
+    @Override
+    public int yi()
+    {
+        return getHost().getPos().getY();
+    }
+
+    @Override
+    public boolean equals(Object object)
+    {
+        if(object == this)
+        {
+            return true;
+        }
+        if(object instanceof NeutronSourceTile)
+        {
+            if(getHost() != null && ((NeutronSourceTile) object).getHost() != null)
+            {
+                return getHost().getWorld() == ((TileEntity) ((NeutronSourceTile) object).getHost()).getWorld() && getHost().getPos() == ((TileEntity) ((NeutronSourceTile) object).getHost()).getPos();
+            }
+            return ((NeutronSourceTile) object).getHost() == getHost();
+        }
+        return false;
+    }
+
+    @Override
+    protected String getDebugName()
+    {
+        return "NeutronSourceTile";
+    }
+
+    @Override
+    public E getHost()
+    {
+        return hostReference.get();
+    }
+}

--- a/src/main/java/com/builtbroken/atomic/map/neutron/thread/NeutronServerTask.java
+++ b/src/main/java/com/builtbroken/atomic/map/neutron/thread/NeutronServerTask.java
@@ -1,0 +1,75 @@
+package com.builtbroken.atomic.map.neutron.thread;
+
+import com.builtbroken.atomic.api.neutron.INeutronNode;
+import com.builtbroken.atomic.api.neutron.INeutronSource;
+import com.builtbroken.atomic.map.neutron.node.NeutronNode;
+import net.minecraft.util.math.BlockPos;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by Pu-238 on 08/22/2020.
+ */
+public class NeutronServerTask implements Runnable
+{
+    public final INeutronSource source;
+    public final HashMap<BlockPos, Integer> collectedData;
+
+    public NeutronServerTask(INeutronSource source, HashMap<BlockPos, Integer> collectedData)
+    {
+        this.source = source;
+        this.collectedData = collectedData;
+    }
+
+    @Override
+    public void run()
+    {
+        //Get data
+        final HashMap<BlockPos, INeutronNode> oldMap = source.getCurrentNodes();
+        final HashMap<BlockPos, INeutronNode> newMap = new HashMap();
+
+        //Remove old data from map
+        source.disconnectMapData();
+
+        //Add new data, recycle old nodes to reduce memory churn
+        for (Map.Entry<BlockPos, Integer> entry : collectedData.entrySet()) //TODO move this to source to give full control over data structure
+        {
+            final int value = entry.getValue();
+            final BlockPos pos = entry.getKey();
+
+            if (oldMap != null && oldMap.containsKey(pos))
+            {
+                final INeutronNode node = oldMap.get(pos);
+                if (node != null)
+                {
+                    //Update value
+                    node.setNeutronValue(value);
+
+                    //Store in new map
+                    newMap.put(pos, node);
+                }
+
+                //Remove from old map
+                oldMap.remove(pos);
+            }
+            else
+            {
+                newMap.put(pos, NeutronNode.get(source, value));
+            }
+        }
+
+        //Clear old data
+        source.disconnectMapData();
+        source.clearMapData();
+
+        //Set new data
+        source.setCurrentNodes(newMap);
+
+        //Tell the source to connect to the map
+        source.connectMapData();
+
+        //Trigger source update
+        source.initMapData();
+    }
+}

--- a/src/main/java/com/builtbroken/atomic/map/neutron/thread/ThreadNeutronExposure.java
+++ b/src/main/java/com/builtbroken/atomic/map/neutron/thread/ThreadNeutronExposure.java
@@ -1,0 +1,219 @@
+package com.builtbroken.atomic.map.neutron.thread;
+
+import com.builtbroken.atomic.AtomicScience;
+import com.builtbroken.atomic.api.map.DataMapType;
+import com.builtbroken.atomic.api.neutron.INeutronNode;
+import com.builtbroken.atomic.api.neutron.INeutronSource;
+import com.builtbroken.atomic.config.server.ConfigServer;
+import com.builtbroken.atomic.lib.neutron.NeutronHandler;
+import com.builtbroken.atomic.map.data.DataChange;
+import com.builtbroken.atomic.map.data.DataPos;
+import com.builtbroken.atomic.map.data.ThreadDataChange;
+import com.builtbroken.atomic.map.data.storage.DataChunk;
+import com.builtbroken.atomic.map.neutron.node.NeutronSourceMap;
+import com.builtbroken.atomic.map.neutron.node.NeutronNode;
+import com.builtbroken.jlib.lang.StringHelpers;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldServer;
+import net.minecraftforge.common.DimensionManager;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.lang.Math.cos;
+import static java.lang.Math.sin;
+
+/**
+ * Handles updating the neutron map
+ * <p>
+ * <p>
+ * Created by Pu-238 on 8/22/2020.
+ */
+public class ThreadNeutronExposure extends ThreadDataChange
+{
+
+    public ThreadNeutronExposure()
+    {
+        super("ThreadNeutronExposure");
+    }
+
+    @Override
+    protected boolean updateLocation(DataChange change)
+    {
+        long time = System.nanoTime();
+
+        final World world = DimensionManager.getWorld(change.dim());
+        if (world != null) //TODO check if world is loaded
+        {
+            final HashMap<BlockPos, Integer> collectedData = updateValue(world, change.xi(), change.yi(), change.zi(), change.value);
+            if (shouldRun)
+            {
+                ((WorldServer) world).addScheduledTask(new NeutronServerTask((INeutronSource) change.source, collectedData));
+            }
+
+            if (AtomicScience.runningAsDev)
+            {
+                time = System.nanoTime() - time;
+                AtomicScience.logger.info(String.format("ThreadNeutronExposure: %sx %sy %sz | %sn | took %s",
+                        change.xi(), change.yi(), change.zi(),
+                        change.value,
+                        StringHelpers.formatNanoTime(time)
+                ));
+            }
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Removes the old value from the map
+     *
+     * @param value - value to remove
+     * @param cx    - change location
+     * @param cy    - change location
+     * @param cz    - change location
+     * @return map of position to edit
+     */
+    protected HashMap<BlockPos, Integer> updateValue(World world, int cx, int cy, int cz, int value)
+    {
+        if (value > 0)
+        {
+            //Track data, also used to prevent editing same tiles (first pos is location, second stores data)
+            final HashMap<BlockPos, Integer> radiationData = new HashMap();
+
+            final int rad = NeutronHandler.getNeutronsFromMaterial(value);
+            final int edit_range = Math.min(ConfigServer.THREAD.THREAD_RADS_PATHING_RANGE, (int) Math.floor(NeutronHandler.getDecayRange(rad)));
+
+            if (edit_range > 1)
+            {
+                //How many steps to go per rotation
+                final int steps = (int) Math.ceil(Math.PI / Math.atan(1.0D / edit_range));
+
+                for (int phi_n = 0; phi_n < 2 * steps; phi_n++)
+                {
+                    for (int theta_n = 0; theta_n < 2 * steps; theta_n++)
+                    {
+                        //Get angles for rotation steps
+                        double yaw = Math.PI * 2 / steps * phi_n;
+                        double pitch = Math.PI * 2 / steps * theta_n;
+
+                        //Figure out vector to move for trace (cut in half to improve trace skipping blocks)
+                        double dx = sin(pitch) * cos(yaw) * 0.5;
+                        double dy = cos(pitch) * 0.5;
+                        double dz = sin(pitch) * sin(yaw) * 0.5;
+
+                        path(radiationData, world,
+                                cx + 0.5, cy + 0.5, cz + 0.5,
+                                dx, dy, dz,
+                                rad, edit_range);
+                    }
+                }
+            }
+            return radiationData;
+        }
+        return new HashMap();
+    }
+
+    protected void path(HashMap<BlockPos, Integer> radiationData, World world,
+                        final double center_x, final double center_y, final double center_z,
+                        final double dx, final double dy, final double dz,
+                        double power, double edit_range)
+    {
+        final int cx = (int) Math.floor(center_x);
+        final int cy = (int) Math.floor(center_y);
+        final int cz = (int) Math.floor(center_z);
+
+        //Position
+        double x = center_x;
+        double y = center_y;
+        double z = center_z;
+
+        double distanceSQ = 1;
+        double radDistance = 1;
+
+        DataPos prevPos = null;
+
+        do
+        {
+            if (!shouldRun)
+            {
+                return;
+            }
+
+            //Convert double position to int position
+            int xi = (int) Math.floor(x);
+            int yi = (int) Math.floor(y);
+            int zi = (int) Math.floor(z);
+
+            if (y < 0 || y > world.getHeight()) //TODO hook into config to allow increase for cubic chunk maps
+            {
+                return;
+            }
+
+            //Ignore center block
+            if (!(xi == cx && yi == cy && zi == cz))
+            {
+
+                //Get distance to center of block from center
+                double distanceX = center_x - (xi + 0.5);
+                double distanceY = center_y - (yi + 0.5);
+                double distanceZ = center_z - (zi + 0.5);
+                distanceSQ = distanceX * distanceX + distanceZ * distanceZ + distanceY * distanceY;
+
+                DataPos pos = DataPos.get(xi, yi, zi);
+
+                //Only do action one time per block (not a perfect solution, but solves double hit on the same block in the same line)
+                if (prevPos != pos)
+                {
+                    //Reduce radiation for distance
+                    power = NeutronHandler.getNeutronsForDistance(power, radDistance, distanceSQ);
+
+                    //Reduce radiation
+                    power = NeutronHandler.reduceNeutronForBlock(world, xi, yi, zi, power);
+
+
+                    //Store change
+                    int change = (int) Math.floor(power);
+                    radiationData.put(pos.disposeReturnBlockPos(), change);
+
+                    //Note previous block
+                    prevPos = pos;
+
+                    //Track last distance of radiation, as power is now measured from that position
+                    radDistance = distanceSQ;
+                }
+                else
+                {
+                    pos.dispose();
+                }
+            }
+
+            //Move forward
+            x += dx;
+            y += dy;
+            z += dz;
+        }
+        while ((distanceSQ <= edit_range * edit_range) && power > 1);
+    }
+
+    /**
+     * Called to scan a chunk to add remove calls
+     *
+     * @param chunk
+     */
+    protected void queueRemove(DataChunk chunk)
+    {
+        chunk.forEachValue((dim, x, y, z, value) -> ThreadNeutronExposure.this.queuePosition(DataChange.get(new NeutronSourceMap(dim, new BlockPos(x, y, z), value), 0)), DataMapType.RAD_MATERIAL); //TODO see if needed
+    }
+
+    /**
+     * Called to scan a chunk to add addition calls
+     *
+     * @param chunk
+     */
+    protected void queueAddition(DataChunk chunk)
+    {
+        chunk.forEachValue((dim, x, y, z, value) -> queuePosition(DataChange.get(new NeutronSourceMap(dim, new BlockPos(x, y, z), value), value)), DataMapType.RAD_MATERIAL);
+    }
+}

--- a/src/main/java/com/builtbroken/atomic/network/packet/sync/PacketPlayerRadiation.java
+++ b/src/main/java/com/builtbroken/atomic/network/packet/sync/PacketPlayerRadiation.java
@@ -17,17 +17,19 @@ public class PacketPlayerRadiation implements IPacket
     public float rads;
     public float rads_area;
     public int rad_remove_timer;
+    public float neus_area;
 
     public PacketPlayerRadiation()
     {
         //Empty for default packet handling
     }
 
-    public PacketPlayerRadiation(float rads, float rads_area, int rad_remove_timer)
+    public PacketPlayerRadiation(float rads, float rads_area, int rad_remove_timer, float neus_area)
     {
         this.rads = rads;
         this.rads_area = rads_area;
         this.rad_remove_timer = rad_remove_timer;
+        this.neus_area = neus_area;
     }
 
     @Override
@@ -36,6 +38,7 @@ public class PacketPlayerRadiation implements IPacket
         buffer.writeFloat(rads);
         buffer.writeFloat(rads_area);
         buffer.writeInt(rad_remove_timer);
+        buffer.writeFloat(neus_area);
     }
 
     @Override
@@ -44,11 +47,13 @@ public class PacketPlayerRadiation implements IPacket
         rads = buffer.readFloat();
         rads_area = buffer.readFloat();
         rad_remove_timer = buffer.readInt();
+        neus_area = buffer.readFloat();
     }
 
     @Override
     public void handleClientSide(EntityPlayer player)
     {
+    	ClientProxy.NEUT_EXPOSURE = neus_area;
         ClientProxy.RAD_EXPOSURE = rads_area;
         ClientProxy.RAD_PLAYER = rads;
         ClientProxy.RAD_REMOVE_TIMER = rad_remove_timer;


### PR DESCRIPTION
Adds neutron radiation as a secondary (and slightly more penetrating) radiation emitted by fission reactor cores. In addition, breeder fuel rods require moderately high levels of this radiation in order to operate in a fission reactor. At least for now neutron radiation shows up in the HUD display measured in neu/s, since there doesn't seem to be an official IRL unit for neutron flux.